### PR TITLE
Added policy_categories.py and policy_packages.py scripts and tidied up the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,18 +263,6 @@ category = Categories().find(141)
 repr(category)
 ```
 
-
-## Using JSSObject
-
-from jamf.jssobjects import ActivationCode, ComputerCheckIn, ComputerInventoryCollection, GSXConnection, JSONWebTokenConfigurations, SMTPServer
-bla = ActivationCode()
-bla.retrieve()
-pprint(bla.data)
-bla.data['activation_code']['organization_name'] = "Wrong"
-bla.put()
-
-from jamf import jssobjects
-
 ## Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ logger.debug("creating api")
 jss = jamf.API()
 ```
 
-### Examples of getting data.
+### Example: Getting data.
 
 Note: The API get method downloads the data from Jamf. If you store it in a variable, it does not update itself. If you make changes on the server, you'll need to run the API get again.
 
@@ -149,7 +149,7 @@ computergroupids = [i['id'] for i in computergroups]
 pprint(computergroupids)
 ```
 
-### Example of posting data.
+### Example: Posting data.
 
 ```python
 # Create a new static computer group. Note, the id in the url ("1") is ignored and the next available id is used. The name in the url ("ignored") is also ignored and the name in the data ("realname") is what is actually used.
@@ -158,7 +158,7 @@ jss.post("computergroups/id/1",json.loads( '{"computer_group": {"name": "test", 
 jss.post("computergroups/name/ignored",json.loads( '{"computer_group": {"name": "realname", "is_smart": "false", "site": {"id": "-1", "name": "None"}, "criteria": {"size": "0"}, "computers": {"size": "0"}}}' ))
 ```
 
-### Examples of updating data.
+### Example: Updating data.
 
 ```python
 # Create a new static computer group. Note, the id ("1") is ignored and the next available id is used.
@@ -168,14 +168,16 @@ jss.put("computergroups/name/realname",json.loads( '{"computer_group": {"name": 
 jss.put("computergroups/id/900",json.loads( '{"computer_group": {"name": "newer name", "is_smart": "false", "site": {"id": "-1", "name": "None"}, "criteria": {"size": "0"}, "computers": {"size": "0"}}}' ))
 ```
 
-### Examples of deleting data.
+### Example: Deleting data.
 
 ```python
 jss.delete("computergroups/name/new name")
 jss.delete("computergroups/id/900")
 ```
 
-### Example: Updating policies en masse
+### Example: Updating policies en masse.
+
+This is where the real power of this utility comes in.
 
 The following example searches all policies for the custom trigger "update_later" and replaces it with "update_now".
 
@@ -233,6 +235,15 @@ chmod 755 custom_triggers_2.py
 
 Then edit custom_triggers_2.py with the custom triggers you want (and remove what you don't want to modify). Then run custom_triggers_2.py.
 
+### Updating policies en masse.
+
+Scripts that do very similar things as the above two scripts are as follows:
+
+* policy_categories.py, allows you to change all policy categories at once
+* policy_packages.py, allows you to change all policy packages at once
+
+Please see the headers of these scripts for instructions. They aren't exactly normal scripts. This is still 0.1.
+
 ## Categories
 
 ```python
@@ -251,6 +262,18 @@ repr(category)
 category = Categories().find(141)
 repr(category)
 ```
+
+
+## Using JSSObject
+
+from jamf.jssobjects import ActivationCode, ComputerCheckIn, ComputerInventoryCollection, GSXConnection, JSONWebTokenConfigurations, SMTPServer
+bla = ActivationCode()
+bla.retrieve()
+pprint(bla.data)
+bla.data['activation_code']['organization_name'] = "Wrong"
+bla.put()
+
+from jamf import jssobjects
 
 ## Running Tests
 

--- a/policy_categories.py
+++ b/policy_categories.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Policy Categories
+
+This script allows you to change the categories of all of your polices at once.
+You must know a little bit of Python to use this script. This script will not
+add categories. Use the GUI for that.
+
+This script isn't standard by any measure. Running this script will generate a
+list of categories and the polices. Here's an example of what it would print.
+
+mass_edit = {
+    'Admin': [
+    ],
+    'Utilities': [
+        'Install RadmindTools',
+    ],
+}
+
+Sooo... basically if you want change the category of the Install RadmindTools
+policy you need to cut it out of the Utilities array and paste it into the
+Admin array, and here's where it gets non-standard, *copy* the code and *paste*
+it into this script. That's right, edit this script. Then run this script
+again. Magic.
+
+To get it to display all of your categories and policies again, just make sure
+you have the following variable empty.
+
+mass_edit = {}
+
+Remember, this script will not add categories.
+"""
+
+__author__ = 'James Reynolds'
+__email__ = 'reynolds@biology.utah.edu'
+__copyright__ = 'Copyright (c) 2020, The University of Utah'
+__license__ = 'MIT'
+__version__ = "1.0.4"
+
+
+import jamf
+
+
+mass_edit = {
+}
+
+jss = jamf.API()
+temp_categories = jss.get('categories')['categories']['category']
+categories = {ii['name']: ii['id'] for ii in temp_categories}
+categories['No category assigned'] = -1
+temp_policies = jss.get('policies')['policies']['policy']
+policies = {ii['name']: ii['id'] for ii in temp_policies}
+
+if len(mass_edit) == 0:
+    for policy_name in policies:
+        policy_id = policies[policy_name]
+        policy = jss.get(f"policies/id/{policy_id}")
+        policy_category_name = policy['policy']['general']['category']['name']
+        if policy_category_name not in mass_edit:
+            mass_edit[policy_category_name] = []
+        mass_edit[policy_category_name].append(policy_name)
+    print("mass_edit = {")
+    for category in categories:
+        print(f"    '{category}': [")
+        if category in mass_edit:
+            for policy_name in mass_edit[category]:
+                print(f"        '{policy_name}',")
+        print("    ],")
+    print("}")
+else:
+    for category_name in mass_edit:
+        policy_arr = mass_edit[category_name]
+        if category_name in categories:
+            for policy_name in policy_arr:
+                if policy_name in policies:
+                    policy_id = policies[policy_name]
+
+                    print(f"Working on {policy_name}")
+                    policy = jss.get(f"policies/id/{policy_id}")
+                    category_dict = {'id': categories[category_name],
+                                     'name': category_name}
+                    policy['policy']['general']['category'] = category_dict
+                    jss.put(f"policies/id/{policy_id}", policy)
+                else:
+                    print(f"ERROR: Policy \"{policy_name}\" is missing")
+        else:
+            print(f"ERROR: Category \"{category_name}\" is missing")

--- a/policy_packages.py
+++ b/policy_packages.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Policy Packages
+
+This script allows you to replace a lot of packages in policies at once. You
+must know a little bit of Python to use this script. This script will not add
+packages to policies. Use the GUI for that.
+
+This script isn't standard by any measure. Running this script will generate a
+list of policies and their packages. The script will attempt to do a prefix
+match based on the regex '^...[^\\d]*' (the 1st three characters and every
+character after that isn't a digit'). If it finds any unused packages that
+match the prefix pattern, it will display it but have it commented out. Here's
+an example of what it would print.
+
+mass_edit = {
+    'Install Zoom': [
+        'Zoom-5.1.27838.0614.pkg',
+#        'Zoom-5.1.28575.0629.pkg',
+#        'Zoom-5.1.28648.0705.pkg',
+    ],
+}
+
+Sooo... basically if you want replace the old Zoom package with a new one,
+comment out the old one and uncomment the new one, and then, and here's where
+it gets non-standard, *copy* the code and *paste* it into this script. That's
+right, edit this script. Then run this script again. Magic.
+
+To get it to display all of your policies and packages again, just make sure
+you have the following variable empty.
+
+mass_edit = {}
+
+Remember, this script will not add packages to policies, only replace them.
+And it will replace packages in the same order they are listed in the policy.
+So if you've done any customization like specify an action or to update
+autorun, those customizations will stick with the package that is in that
+order.
+
+For example, if you have a policy with 2 packages and the first package has
+update autorun data checked, and you replace both packages with new ones, the
+first one will still have update autorun data checked.
+
+This script does not check the values for "Fill user templates (FUT)" or
+"Fill existing user home directories (FEU)", which are package settings, not
+policy settings. This matters because these settings are also stored in the
+policy. So whatever the old package was, that's what the new package will be
+too.
+"""
+
+__author__ = 'James Reynolds'
+__email__ = 'reynolds@biology.utah.edu'
+__copyright__ = 'Copyright (c) 2020, The University of Utah'
+__license__ = 'MIT'
+__version__ = "1.0.4"
+
+
+import jamf
+import re
+
+
+mass_edit = {
+}
+
+jss = jamf.API()
+temp_pkgs = jss.get('packages')['packages']['package']
+pkgs = {ii['name']: ii['id'] for ii in temp_pkgs}
+
+temp_policies = jss.get('policies')['policies']['policy']
+policies = {ii['name']: ii['id'] for ii in temp_policies}
+
+if len(mass_edit) == 0:
+    used_pkgs = {}
+    for policy_name in policies:
+        policy_id = policies[policy_name]
+        policy = jss.get(f"policies/id/{policy_id}")
+
+        policy_pkgs = policy['policy']['package_configuration']['packages']
+        if 'package' in policy_pkgs:
+            mass_edit[policy_name] = []
+            if policy_pkgs['size'] == '1':
+                mypkgs = [policy_pkgs['package']]
+            else:
+                mypkgs = policy_pkgs['package']
+            for pkg in mypkgs:
+                mass_edit[policy_name].append(pkg['name'])
+                used_pkgs[pkg['name']] = True
+    unused_pkgs = list(filter(lambda i: i not in used_pkgs, pkgs))
+    print("mass_edit = {")
+    for policy_name in mass_edit:
+        print(f"    '{policy_name}': [")
+        for pkg in mass_edit[policy_name]:
+            print(f"        '{pkg}',")
+            prefix = re.sub(r"^(...[^\d]*).*", "\\1", pkg)
+            for unused_pkg in unused_pkgs:
+                if re.match(prefix, unused_pkg):
+                    print(f"#        '{unused_pkg}',")
+                    used_pkgs[unused_pkg] = True
+        print("    ],")
+    print("}")
+    print("# Unused Packages:")
+    unused_pkgs = list(filter(lambda ii: ii not in used_pkgs, pkgs))
+    for unused_pkg in unused_pkgs:
+        print(f"#        '{unused_pkg}',")
+else:
+    for policy_name in mass_edit:
+        print(f"Working on {policy_name}")
+        pkg_arr = mass_edit[policy_name]
+        if policy_name not in policies:
+            print(f"ERROR: Policy \"{policy_name}\" is unknown")
+            exit(1)
+        policy_id = policies[policy_name]
+        policy = jss.get(f"policies/id/{policy_id}")
+        policy_pkgs = policy['policy']['package_configuration']['packages']
+        for pkg_index, pkg_name in enumerate(pkg_arr):
+            if pkg_name not in pkgs:
+                print(f"ERROR: Package \"{pkg_name}\" is unknown")
+                exit(1)
+            if int(policy_pkgs['size']) != len(pkg_arr):
+                print(f"ERROR: Policy \"{policy_name}\" has "
+                      f"{policy_pkgs['size']} package(s) and "
+                      f"you're trying to replace {len(pkg_arr)} package(s). "
+                      f"You must specify the same number of packages.\n")
+                exit(1)
+
+            if policy_pkgs['size'] == '1':
+                new_pkg_id = pkgs[pkg_name]
+                policy_pkgs['package']['id'] = new_pkg_id
+                policy_pkgs['package']['name'] = pkg_name
+            else:
+                new_pkg_id = pkgs[pkg_name]
+                policy_pkgs['package'][pkg_index]['id'] = new_pkg_id
+                policy_pkgs['package'][pkg_index]['name'] = pkg_name
+        jss.put(f"policies/id/{policy_id}", policy)


### PR DESCRIPTION
policy_categories.py and policy_packages.py scripts that allow you to change all policy packages and categories at once. This is still 0.1, so the scripts aren't exactly command line friendly. See the headers of the files for instructions.