### PR TITLE
Added jctl

### DIFF
--- a/jctl
+++ b/jctl
@@ -16,8 +16,8 @@ __author__ = 'Sam Forester'
 __email__ = 'sam.forester@utah.edu'
 __copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
 __license__ = 'MIT'
-__version__ = "1.0.6"
-min_jamf_version = "0.4.9"
+__version__ = "1.0.7"
+min_jamf_version = "0.5.0"
 
 
 from pprint import pprint
@@ -52,75 +52,86 @@ class Parser:
         #######################################################################
         # Info
 
-        info = self.subparsers.add_parser('info', help='list',
-             description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
-        info.add_argument('record', metavar='RECORD',
+        info_ = self.subparsers.add_parser('info', help='list',
+             description='Valid Jamf Records are: '+
+                         ', '.join(valid_jamf_records))
+        info_.add_argument('record', metavar='RECORD',
             choices=valid_jamf_records, help='print jamf record info')
-        info.add_argument('name', metavar='NAME', nargs='*',
+        info_.add_argument('name', metavar='NAME', nargs='*',
             help='print jamf record info')
-        info.add_argument('-p', '--path', action='append',
+        info_.add_argument('-j', '--json', action='store_true',
+            help='Print json')
+        info_.add_argument('-p', '--path', action='append',
             help='Print out path (e.g. \'-p general -p serial_number\'')
 
         # Package args
-        info.add_argument('-f', '--file', action='store_true',
-            help='path to pkg file (only works with Packages, was `patch.py info FILE`)')
+        info_.add_argument('-f', '--file', action='store_true',
+            help='path to pkg file (only works with Packages, was `patch.py'
+                 'info FILE`)')
 
         # Patch args
-        info.add_argument('-P', '--patches', action='store_true',
+        info_.add_argument('-P', '--patches', action='store_true',
             help='list patch policies current versions for '
                  'SoftwareTitle NAME')
-        info.add_argument('-v', '--versions', action='store_true',
+        info_.add_argument('-v', '--versions', action='store_true',
             help='info SoftwareTitle versions and packages for NAME'
                  ' (was `patch.py list --versions NAME`)')
 
         #######################################################################
         # List
 
-        list = self.subparsers.add_parser('list', help='list',
+        list_ = self.subparsers.add_parser('list', help='list',
              description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
-        list.add_argument('record', metavar='RECORD',
+        list_.add_argument('record', metavar='RECORD',
             choices=valid_jamf_records, help='list jamf records')
-        list.add_argument('name', metavar='REGEX', action='store', nargs='?',
+        list_.add_argument('name', metavar='REGEX', action='store', nargs='?',
             help='list jamf records with names that match REGEX')
+        list_.add_argument('-p', '--path', action='append',
+            help='Print out path (e.g. \'-p general -p serial_number\' Note:'
+                 'Using this forces jctl to load each record, slowing it down')
 
         #######################################################################
         # New
 
-        neu = self.subparsers.add_parser('new', help='new',
-             description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
-        neu.add_argument('record', metavar='RECORD',
+        new_ = self.subparsers.add_parser('new', help='new',
+             description='Adds record. Valid Jamf Records are: '+
+                         ', '.join(valid_jamf_records))
+        new_.add_argument('record', metavar='RECORD',
             choices=valid_jamf_records, help='new jamf record')
-        neu.add_argument('name', metavar='NAME',
-            help='new jamf records')
+        new_.add_argument('data', metavar='DATA', action='store', nargs='?',
+            help='Data to add. - will read from STDIN')
+        new_.add_argument('-f', '--file', help='path to json file')
 
         #######################################################################
-        # Remove
+        # Delete
 
-        remove = self.subparsers.add_parser('remove', help='remove',
+        delete_ = self.subparsers.add_parser('delete', help='delete',
              description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
-        remove.add_argument('record', metavar='RECORD',
-            choices=valid_jamf_records, help='remove jamf record')
-        remove.add_argument('name', metavar='REGEX', action='store', nargs='?',
-            help='remove jamf records with names that match REGEX')
+        delete_.add_argument('record', metavar='RECORD',
+            choices=valid_jamf_records, help='delete jamf record')
+        delete_.add_argument('name', metavar='REGEX', action='store', nargs='?',
+            help='delete jamf records with names that match REGEX')
+        delete_.add_argument('-f', '--force', action='store_true',
+            help="Don't ask to delete. DANGER! This can delete everything!")
 
         #######################################################################
         # Update
 
-        update = self.subparsers.add_parser('update', help='update',
+        update_ = self.subparsers.add_parser('update', help='update',
              description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
-        update.add_argument('record', metavar='RECORD',
+        update_.add_argument('record', metavar='RECORD',
             choices=valid_jamf_records, help='update jamf record')
-        update.add_argument('name', metavar='REGEX', action='store', nargs='?',
+        update_.add_argument('name', metavar='REGEX', action='store', nargs='?',
             help='update jamf record')
 
         #######################################################################
         # Upload
 
-        upload = self.subparsers.add_parser('upload', help='upload',
+        upload_ = self.subparsers.add_parser('upload', help='upload',
              description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
-        upload.add_argument('record', metavar='RECORD',
+        upload_.add_argument('record', metavar='RECORD',
             choices=['Packages'], help='upload jamf record')
-        upload.add_argument('name', metavar='REGEX', action='store', nargs='?',
+        upload_.add_argument('name', metavar='REGEX', action='store', nargs='?',
             help='upload jamf record')
 
     def parse(self, argv):
@@ -337,6 +348,25 @@ def softwaretitle_policies(api, jssid):
 
 ###############################################################################
 
+def print_path(results):
+    if results and len(results) > 0:
+        for result in results:
+            if isinstance(result, str):
+                print(result+"\t")
+            else:
+                print(result)
+    print()
+
+def confirm(_message):
+    """
+    Ask user to enter Y or N (case-insensitive).
+    :return: True if the answer is Y.
+    :rtype: bool
+    """
+    answer = ""
+    while answer not in ["y", "n"]:
+        answer = input(_message).lower()
+    return answer == "y"
 
 def main(argv):
     logger = logging.getLogger(__name__)
@@ -359,16 +389,16 @@ def main(argv):
         api = jamf.API()
 
     if args.record:
-        jamf_record = jamf.records.class_name(args.record)
+        jamf_record_class = jamf.records.class_name(args.record)
 
     ###########################################################################
     # Info
     if args.arg1 == 'info':
-        for name in args.name:
+        for name_ in args.name:
             if args.file:
                 if args.record == "Packages":
                     # `patch.py info FILE`
-                    pprint(Package(name).apps)
+                    pprint(Package(name_).apps)
                 else:
                     print("-f only works for Packages")
                     exit(1)
@@ -376,7 +406,7 @@ def main(argv):
             elif args.patches:
                 if args.record == "PatchSoftwareTitles":
                     # `patch.py list --patches NAME`
-                    list_softwaretitle_policy_versions(api, name)
+                    list_softwaretitle_policy_versions(api, name_)
                 else:
                     print("-P only works for PatchSoftwareTitles")
                     exit(1)
@@ -384,42 +414,59 @@ def main(argv):
             elif args.versions:
                 if args.record == "PatchSoftwareTitles":
                     # `patch.py list --versions NAME`
-                    list_softwaretitle_versions(api, name)
+                    list_softwaretitle_versions(api, name_)
                 else:
                     print("-v only works for PatchSoftwareTitles")
                     exit(1)
 
             else:
-                if args.record in ["PatchSoftwareTitles"]:
-                    # Workaround (PatchSoftwareTitles doesn't have name search)
-                    # This might need to be made generic in records.py
-                    id = jamf_record().id(name)
-                    if args.path:
-                        print(jamf_record(id).path(args.path))
-                    else:
-                        jamf_record(id).print()
-
+                if args.path:
+                    print_path(jamf_record_class(name_).path(args.path))
                 else:
-                    # EVERYTHING ELSE
-                    if args.path:
-                        print(jamf_record(name).path(args.path))
+                    if args.json:
+                        print(jamf_record_class(name_).json())
                     else:
-                        jamf_record(name).print()
+                        jamf_record_class(name_).print()
 
     ###########################################################################
     # List
     elif args.arg1 == 'list':
-        jamf_record().list(args.name)
+        results = jamf_record_class().list(args.name)
+        if results:
+            for name_ in results:
+                if args.path:
+                    print_path(jamf_record_class(name_).path(args.path))
+                else:
+                    print(name_)
 
     ###########################################################################
     # New
     elif args.arg1 == 'new':
-        print("new")
+        if args.data:
+            if args.data == "-":
+                jamf_record_class(json_data=sys.stdin)
+            elif args.data != "":
+                jamf_record_class(python_data=args.data)
+        elif args.file:
+            jamf_record_class(json_file=args.file)
+        else:
+            timmy.parser.print_help()
+            print("\nSpecify data to add or - to read from STDIN")
+            exit(1)
 
     ###########################################################################
-    # Remove
-    elif args.arg1 == 'remove':
-        print("remove")
+    # Delete
+    elif args.arg1 == 'delete':
+        results = jamf_record_class().list(args.name, ids=True)
+        if results:
+            for name_ in results:
+                pprint(name_)
+                if args.force:
+                    doit = True
+                else:
+                    doit = confirm("Are you sure you want to delete this record [Y/N]? ")
+                if doit:
+                    jamf_record_class(name_).delete()
 
 # Package
 #             path = pathlib.Path(args.name)
@@ -429,7 +476,7 @@ def main(argv):
 #             try:
 #                 pkg = admin.find(path.name)
 #             except jamf.admin.MissingPackageError:
-#                 logger.error(f"package already removed: {path.name}")
+#                 logger.error(f"package already deleted: {path.name}")
 #             else:
 #                 admin.delete(pkg)
     ###########################################################################
@@ -471,8 +518,13 @@ def main(argv):
 #                 uploaded = admin.find(pkg.name)
 #             admin.update(uploaded, notes=package_notes(uploaded.path))
 
+    else:
+        timmy.parser.print_help()
 
 if __name__ == '__main__':
     fmt = '%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s'
     logging.basicConfig(level=logging.INFO, format=fmt)
-    main(sys.argv[1:])
+    try:
+        main(sys.argv[1:])
+    except KeyboardInterrupt:
+            sys.exit(1)

--- a/jctl
+++ b/jctl
@@ -16,8 +16,8 @@ __author__ = 'Sam Forester'
 __email__ = 'sam.forester@utah.edu'
 __copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
 __license__ = 'MIT'
-__version__ = "1.0.4"
-min_jamf_version = "0.4.7"
+__version__ = "1.0.5"
+min_jamf_version = "0.4.8"
 
 
 from pprint import pprint
@@ -34,115 +34,91 @@ from jamf.package import Package
 
 class Parser:
     def __init__(self):
+        valid_jamf_records = jamf.records.valid_records()
         self.parser = argparse.ArgumentParser()
         # https://docs.python.org/3/library/argparse.html
 
-        self.parser.add_argument('-c', '--config',
-                            help='path to config file')
+        self.parser.add_argument('-c', '--config', help='path to config file')
+
+        self.parser.add_argument('-v', '--version', action='store_true',
+            help='print version and exit')
 
         desc = 'see `%(prog)s COMMAND --help` for more information'
         self.subparsers = self.parser.add_subparsers(title='COMMANDS',
-                            dest='arg1',
-                            metavar='{category|computer|computer_group|package|patch|policy}',
-                            required=True,
-                            description=desc)
+            dest='arg1',
+#             required=True,
+            description=desc)
 
-        # Categories
-        category = self.subparsers.add_parser('category',
-                            help='list, update',
-                            description="")
-        category2 = category.add_subparsers(title='SUBCOMMANDS',
-                            metavar='{list}',
-                            dest='arg2',
-                            required=True)
-        category2.add_parser('list',
-                            help='List all categories')
+        #######################################################################
+        # Info
 
-        # Computers
-        computer = self.subparsers.add_parser('computer', help='list',
-                            description="")
-        computer2 = computer.add_subparsers(title='SUBCOMMANDS',
-                            metavar='{list}',
-                            dest='arg2',
-                            required=True)
-        computer2.add_parser('list',
-                            help='List all computers')
+        info = self.subparsers.add_parser('info', help='list',
+             description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
+        info.add_argument('record', metavar='RECORD',
+            choices=valid_jamf_records, help='print jamf record info')
+        info.add_argument('name', metavar='NAME', help='print jamf record info')
 
-        # Computer Group
-        computer_group = self.subparsers.add_parser('computer_group',
-                            help='list',
-                            description="")
-        computer_group2 = computer_group.add_subparsers(title='SUBCOMMANDS',
-                            metavar='{list}',
-                            dest='arg2',
-                            required=True)
-        computer_group2.add_parser('list',
-                            help='List all computer groups')
+        # Package args
+        info.add_argument('-f', '--file', action='store_true',
+            help='path to pkg file (only works with Packages, was `patch.py info FILE`)')
 
-        # Config Profiles
-        config_profile = self.subparsers.add_parser('config_profile', help='list',
-                            description="")
-        config_profile2 = config_profile.add_subparsers(title='SUBCOMMANDS',
-                            metavar='{list}',
-                            dest='arg2',
-                            required=True)
-        config_profile2.add_parser('list',
-                            help='List all Config Profiles')
+        # Patch args
+        info.add_argument('-P', '--patches', action='store_true',
+            help='list patch policies current versions for '
+                 'SoftwareTitle NAME')
+        info.add_argument('-v', '--versions', action='store_true',
+            help='info SoftwareTitle versions and packages for NAME'
+                 ' (was `patch.py list --versions NAME`)')
 
-        # Package
-        package = self.subparsers.add_parser('package',
-                            help='info, list, remove, upload',
-                            description="")
-        package2 = package.add_subparsers(title='SUBCOMMANDS',
-                            metavar='{info|list|remove|upload}',
-                            dest='arg2',
-                            required=True)
-        package_info = package2.add_parser('info',
-                            help='get info about packages')
-        package_info.add_argument('path', metavar='PACKAGE',
-                            help='path to package')
+        #######################################################################
+        # List
 
-        package_list = package2.add_parser('list',
-                            help='list packages starting with NAME (or all if no NAME) (was `patch.py list --pkgs`)')
-        package_list.add_argument('name', metavar='NAME', action='store', nargs='?',
-                            help='list patch that starts with name')
+        list = self.subparsers.add_parser('list', help='list',
+             description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
+        list.add_argument('record', metavar='RECORD',
+            choices=valid_jamf_records, help='list jamf records')
+        list.add_argument('name', metavar='REGEX', action='store', nargs='?',
+            help='list jamf records with names that match REGEX')
 
-        package2.add_parser('remove',
-                            help='Remove a package')
-        package2.add_parser('upload',
-                            help='Upload package')
+        #######################################################################
+        # New
 
-        # Patch
-        desc = 'see `%(prog)s SUBCOMMAND --help` for more information'
-        patch = self.subparsers.add_parser('patch', help='list, update',
-                            description=desc)
-        patch2 = patch.add_subparsers(title='SUBCOMMANDS',
-                            metavar='{list|update}',
-                            dest='arg2',
-                            required=True)
-        patch_list = patch2.add_parser('list',
-                            help='without arguments, list all software titles (was `./patch.py list [NAME]`)')
-        patch_list.add_argument('name', metavar='NAME', action='store', nargs='?',
-                            help='list patch that starts with name')
-        patch_list.add_argument('-P', '--patches', action='store_true',
-                            help='list patch policies current versions for SoftwareTitle NAME')
-        patch_list.add_argument('-v', '--versions', action='store_true',
-                            help='list SoftwareTitle versions and packages for NAME (was `patch.py list --versions NAME`)')
+        neu = self.subparsers.add_parser('new', help='new',
+             description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
+        neu.add_argument('record', metavar='RECORD',
+            choices=valid_jamf_records, help='new jamf record')
+        neu.add_argument('name', metavar='NAME',
+            help='new jamf records')
 
-        patch2.add_parser('update',
-                            help='Update patch')
+        #######################################################################
+        # Remove
 
-        # Policy
-        policy = self.subparsers.add_parser('policy',
-                            help='list',
-                            description="")
-        policy2 = policy.add_subparsers(title='SUBCOMMANDS',
-                            metavar='{list}',
-                            dest='arg2',
-                            required=True)
-        policy2.add_parser('list',
-                            help='List all policies (was `patch.py list --ids`)')
+        remove = self.subparsers.add_parser('remove', help='remove',
+             description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
+        remove.add_argument('record', metavar='RECORD',
+            choices=valid_jamf_records, help='remove jamf record')
+        remove.add_argument('name', metavar='REGEX', action='store', nargs='?',
+            help='remove jamf records with names that match REGEX')
 
+        #######################################################################
+        # Update
+
+        update = self.subparsers.add_parser('update', help='update',
+             description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
+        update.add_argument('record', metavar='RECORD',
+            choices=valid_jamf_records, help='update jamf record')
+        update.add_argument('name', metavar='REGEX', action='store', nargs='?',
+            help='update jamf record')
+
+        #######################################################################
+        # Upload
+
+        upload = self.subparsers.add_parser('upload', help='upload',
+             description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
+        upload.add_argument('record', metavar='RECORD',
+            choices=['Packages'], help='upload jamf record')
+        upload.add_argument('name', metavar='REGEX', action='store', nargs='?',
+            help='upload jamf record')
 
     def parse(self, argv):
         """
@@ -160,11 +136,13 @@ def check_version():
         if ( int(jamf_first) <= int(min_first) and
              int(jamf_second) <= int(min_second) and
              int(jamf_third) < int(min_third)):
-             print(f"Your Version is: {jamf.__version__}, you need at least version {min_jamf_version} to run jctl.")
+             print(f"Your Version is: {jamf.__version__}, you need at least "
+                   f"version {min_jamf_version} to run this version of jctl.")
              sys.exit()
 
     except AttributeError:
-             print(f"Your Version is below 0.4.2, you need at least version {min_jamf_version} to run jctl.")
+             print(f"Your Version is below 0.4.2, you need at least version "
+                   f"{min_jamf_version} to run this version of jctl.")
              sys.exit()
 
 
@@ -173,19 +151,6 @@ def check_version():
 ###############################################################################
 # Package
 ###############################################################################
-
-def list_packages(api, name=None):
-    p = api.get('packages')
-    pkgs = p['packages']['package']
-    if name:
-        # only names that start with name (case-sensitive)
-        result = [x['name'] for x in pkgs if x['name'].lower().startswith(name.lower())]
-    else:
-        # all names
-        result = [x['name'] for x in pkgs]
-    # print sorted list of resulting Patch SoftwareTitle names
-    for n in sorted(result):
-        print(n)
 
 # def package_notes(path):
 #     path = pathlib.Path(path)
@@ -224,7 +189,7 @@ def list_softwaretitle_versions(api, name):
 def find_softwaretitle(api, name, details=True):
     """
     :param api:         jamf.api.API object
-    :param name:        name of softwaretitle
+    :param name:        softwaretitle name
     :param details:     if False, return simple (id + name) (default: True)
 
     :returns:           patch softwaretitle information
@@ -271,28 +236,28 @@ def print_version_key_list(versions):
         justification = (longest - len(ver)) + len(value)
         print(f"  {ver}:  {value:>{justification}}")
 
-# def list_softwaretitle_policy_versions(api, name):
-#     jssid = find_softwaretitle(api, name, details=False)['id']
-#     versions = []
-#     for patch in softwaretitle_policies(api, jssid):
-#         p = api.get(f"patchpolicies/id/{patch['id']}")
-#         version = p['patch_policy']['general']['target_version']
-#         versions.append((version, patch['name']))
-#     # print formatted result
-#     print_version_key_list(versions)
-#
-# def softwaretitle_policies(api, jssid):
-#     """
-#     :returns: list of software title patch policies
-#     """
-#     endpoint = f"patchpolicies/softwaretitleconfig/id/{jssid}"
-#     return api.get(endpoint)['patch_policies']['patch_policy']
-#
+def list_softwaretitle_policy_versions(api, name):
+    jssid = find_softwaretitle(api, name, details=False)['id']
+    versions = []
+    for patch in softwaretitle_policies(api, jssid):
+        p = api.get(f"patchpolicies/id/{patch['id']}")
+        version = p['patch_policy']['general']['target_version']
+        versions.append((version, patch['name']))
+    # print formatted result
+    print_version_key_list(versions)
+
+def softwaretitle_policies(api, jssid):
+    """
+    :returns: list of software title patch policies
+    """
+    endpoint = f"patchpolicies/softwaretitleconfig/id/{jssid}"
+    return api.get(endpoint)['patch_policies']['patch_policy']
+
 # def update_softwaretitle_versions(api, name, versions, pkgs=None):
 #     """
 #     Update all
 #     :param api:      JSS API object
-#     :param name:     name of external patch definition
+#     :param name:     external patch definition name
 #     :param versions: {'Tech': version, 'Guinea Pig': version, 'Stable': version}
 #     :returns:
 #     """
@@ -368,62 +333,81 @@ def print_version_key_list(versions):
 #         logger.info(f"software title was not modified")
 
 ###############################################################################
-# Policy
-###############################################################################
-
-def print_policies_ids(api):
-    (ids, id_name) = list_policies_ids(api)
-    for b in range(len(ids)):
-        print("ID: " + ids[b] + " Name: " + id_name[b])
-
-def list_policies_ids(api):
-    p = api.get('policies')
-    pls = p['policies']['policy']
-    ids = [x['id'] for x in pls]
-    id_name = [x['name'] for x in pls]
-    return(ids, id_name)
-
-###############################################################################
 
 
 def main(argv):
     logger = logging.getLogger(__name__)
-    args = Parser().parse(argv)
+    timmy = Parser()
+    args = timmy.parse(argv)
+    valid_jamf_records = jamf.records.valid_records()
     logger.debug(f"args: {args!r}")
-    pprint(args)
+
+    if args.version:
+        print("jctl "+__version__)
+        print("python_jamf "+jamf.__version__+ " ("+min_jamf_version+" required)")
+        exit()
+
+    check_version()
+    #pprint(args)
 
     if args.config:
         api = jamf.API(config_path=args.config)
     else:
         api = jamf.API()
 
-    if args.arg1 == 'category':
-        if 'list' in args.arg2:
-            print("category list")
-    elif args.arg1 == 'computer':
-        if 'list' in args.arg2:
-            print("computer list")
-    elif args.arg1 == 'computer_group':
-        if 'list' in args.arg2:
-            print("computer_group list")
-    elif args.arg1 == 'config':
-        if 'list' in args.arg2:
-            print("config list")
-    elif args.arg1 == 'config_profile':
-        if 'list' in args.arg2:
-            print("config_profile list")
+    ###########################################################################
+    # Info
+    if args.arg1 == 'info':
+        if args.file:
+            if args.record == "Packages":
+                # `patch.py info FILE`
+                pprint(Package(args.name).apps)
+            else:
+                print("-f only works for Packages")
+                exit(1)
 
-    elif args.arg1 == 'package':
-        if 'info' in args.arg2:
-            pprint(Package(args.path).apps)
+        elif args.patches:
+            if args.record == "PatchSoftwareTitles":
+                # `patch.py list --patches NAME`
+                list_softwaretitle_policy_versions(api, args.name)
+            else:
+                print("-P only works for PatchSoftwareTitles")
+                exit(1)
 
-        if 'list' in args.arg2:
-            # `patch.py list --pkgs`
-            list_packages(api, args.name)
+        elif args.versions:
+            if args.record == "PatchSoftwareTitles":
+                # `patch.py list --versions NAME`
+                list_softwaretitle_versions(api, args.name)
+            else:
+                print("-v only works for PatchSoftwareTitles")
+                exit(1)
 
-        if 'remove' in args.arg2:
-            print("package remove")
+        else:
+            if args.record in ["PatchSoftwareTitles"]:
+                # Workaround (PatchSoftwareTitles doesn't have name search)
+                id = jamf.records.class_name(args.record)().id(args.name)
+                jamf.records.class_name(args.record)(id).print()
 
+            else:
+                # EVERYTHING ELSE
+                jamf.records.class_name(args.record)(args.name).print()
+
+    ###########################################################################
+    # List
+    elif args.arg1 == 'list':
+        jamf.records.class_name(args.record)().list(args.name)
+
+    ###########################################################################
+    # New
+    elif args.arg1 == 'new':
+        print("new")
+
+    ###########################################################################
+    # Remove
+    elif args.arg1 == 'remove':
+        print("remove")
+
+# Package
 #             path = pathlib.Path(args.name)
 #             if path.name != str(path):
 #                 raise SystemExit("must specify package name not path")
@@ -434,10 +418,30 @@ def main(argv):
 #                 logger.error(f"package already removed: {path.name}")
 #             else:
 #                 admin.delete(pkg)
+    ###########################################################################
+    # Update
+    elif args.arg1 == 'update':
+        print("update")
 
-        if 'upload' in args.arg2:
-            print("package upload")
+# Patch
+#             # update patch software titles and/or patch policies
+#             v = {'Tech': args.tech,
+#                  'Guinea Pig': args.guinea_pig,
+#                  'Stable': args.stable}
+#             versions = {k:v for k, v in v.items() if v}
+#             pkgs = {x[0]: x[1] for x in args.pkg}
+#
+#             logger.debug(f"NAME: {args.name}")
+#             logger.debug(f"VERSIONS: {versions!r}")
+#             logger.debug(f"PKGS: {pkgs!r}")
+#
+#             update_softwaretitle_versions(api, args.name, versions, pkgs)
+    ###########################################################################
+    # Upload
+    elif args.arg1 == 'upload':
+       print("upload")
 
+# Package
 #             pkg = Package(args.path)
 #             # try:
 #             #     info = pkg.info
@@ -453,46 +457,8 @@ def main(argv):
 #                 uploaded = admin.find(pkg.name)
 #             admin.update(uploaded, notes=package_notes(uploaded.path))
 
-    elif args.arg1 == 'patch':
-        if 'list' in args.arg2:
-            if args.patches:
-                # `patch.py list --patches NAME`
-                if not args.name:
-                    raise SystemExit("ERROR: must specify SoftwareTitle name")
-                list_softwaretitle_policy_versions(api, args.name)
-            elif args.versions:
-                # `patch.py list --versions NAME`
-                if not args.name:
-                    raise SystemExit("ERROR: must specify SoftwareTitle name")
-                list_softwaretitle_versions(api, args.name)
-            else:
-                # `patch.py list [NAME]`
-                list_softwaretitles(api, args.name)
-
-        elif 'update' in args.arg2:
-            print("patch update")
-
-#             # update patch software titles and/or patch policies
-#             v = {'Tech': args.tech,
-#                  'Guinea Pig': args.guinea_pig,
-#                  'Stable': args.stable}
-#             versions = {k:v for k, v in v.items() if v}
-#             pkgs = {x[0]: x[1] for x in args.pkg}
-#
-#             logger.debug(f"NAME: {args.name}")
-#             logger.debug(f"VERSIONS: {versions!r}")
-#             logger.debug(f"PKGS: {pkgs!r}")
-#
-#             update_softwaretitle_versions(api, args.name, versions, pkgs)
-
-    elif args.arg1 == 'policy':
-        if 'list' in args.arg2:
-            # `patch.py list --ids`
-            print_policies_ids(api)
-
 
 if __name__ == '__main__':
-    # check_version()
     fmt = '%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s'
     logging.basicConfig(level=logging.INFO, format=fmt)
     main(sys.argv[1:])

--- a/jctl
+++ b/jctl
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Interact with Jamf Pro Server
+
+Examples:
+
+# List app policies
+$> pctl policy list
+
+"""
+
+
+__author__ = 'James Reynolds'
+__email__ = 'reynolds@biology.utah.edu'
+__copyright__ = 'Copyright (c) 2020, The University of Utah'
+__license__ = 'MIT'
+__version__ = "1.0.4"
+min_jamf_version = "0.4.7"
+
+
+from pprint import pprint
+import argparse
+import jamf
+import logging
+import pathlib
+import sys
+
+#import jamf.admin
+from jamf.package import Package
+#import jamf.config
+
+
+class Parser:
+    def __init__(self):
+        self.parser = argparse.ArgumentParser()
+        # https://docs.python.org/3/library/argparse.html
+
+        desc = 'see `%(prog)s COMMAND --help` for more information'
+        self.subparsers = self.parser.add_subparsers(title='COMMANDS',
+                            dest='arg1',
+                            metavar='{package|patch|policy}',
+                            required=True,
+                            description=desc)
+
+        # Package
+        package = self.subparsers.add_parser('package',
+                            help='info, list, remove, update, upload',
+                            description="")
+        package2 = package.add_subparsers(title='SUBCOMMANDS',
+                            metavar='{info|list|remove|update|upload}',
+                            dest='arg2',
+                            required=True)
+        package2.add_parser('info',
+                            help='Package info')
+        package2.add_parser('list',
+                            help='List all packages')
+        package2.add_parser('remove',
+                            help='Remove a package')
+        package2.add_parser('update',
+                            help='Update a package description')
+        package2.add_parser('upload',
+                            help='Upload package')
+
+        # Patch
+        desc = 'see `%(prog)s SUBCOMMAND --help` for more information'
+        patch = self.subparsers.add_parser('patch', help='list, update',
+                            description=desc)
+        patch2 = patch.add_subparsers(title='SUBCOMMANDS',
+                            metavar='{list|update}',
+                            dest='arg2',
+                            required=True)
+        patch_list = patch2.add_parser('list',
+                            help='without arguments, list all software titles (was `./patch.py list`)')
+        patch_list.add_argument('name', metavar='NAME', action='store', nargs='?',
+                            help='list patch that starts with name')
+        patch_list.add_argument('-p', '--pkgs', action='store_true',
+                            help='list jss packages starting with NAME (or all if no NAME)')
+        patch_list.add_argument('-P', '--patches', action='store_true',
+                            help='list patch policies current versions for SoftwareTitle NAME')
+        patch_list.add_argument('-v', '--versions', action='store_true',
+                            help='list SoftwareTitle versions and packages for NAME')
+
+        patch2.add_parser('update',
+                            help='Update patch')
+
+        # Policy
+        policy = self.subparsers.add_parser('policy',
+                            help='list',
+                            description="")
+        policy2 = policy.add_subparsers(title='SUBCOMMANDS',
+                            metavar='{list}',
+                            dest='arg2',
+                            required=True)
+        policy2.add_parser('list',
+                            help='List all policies (was `patch.py list --ids`)')
+
+
+    def parse(self, argv):
+        """
+        :param argv:    list of arguments to parse
+        :returns:       argparse.NameSpace object
+        """
+        return self.parser.parse_args(argv)
+
+def check_version():
+
+    try:
+        jamf_first, jamf_second, jamf_third = jamf.__version__.split(".")
+        min_first, min_second, min_third = min_jamf_version.split(".")
+
+        if ( int(jamf_first) <= int(min_first) and
+             int(jamf_second) <= int(min_second) and
+             int(jamf_third) < int(min_third)):
+             print(f"Your Version is: {jamf.__version__}, you need at least version {min_jamf_version} to run jctl.")
+             sys.exit()
+
+    except AttributeError:
+             print(f"Your Version is below 0.4.2, you need at least version {min_jamf_version} to run jctl.")
+             sys.exit()
+
+
+###############################################################################
+
+###############################################################################
+# Package
+###############################################################################
+
+###############################################################################
+# Patch
+###############################################################################
+
+def list_softwaretitles(api, name=None):
+    p = api.get('patchsoftwaretitles')
+    titles = p['patch_software_titles']['patch_software_title']
+    if name:
+        # only names that start with name (case-sensitive)
+        result = [x['name'] for x in titles if x['name'].startswith(name)]
+    else:
+        # all names
+        result = [x['name'] for x in titles]
+    # print sorted list of resulting Patch SoftwareTitle names
+    for n in sorted(result):
+        print(n)
+
+###############################################################################
+# Policy
+###############################################################################
+
+def print_policies_ids(api):
+    (ids, id_name) = list_policies_ids(api)
+    for b in range(len(ids)):
+        print("ID: " + ids[b] + " Name: " + id_name[b])
+
+def list_policies_ids(api):
+    p = api.get('policies')
+    pls = p['policies']['policy']
+    ids = [x['id'] for x in pls]
+    id_name = [x['name'] for x in pls]
+    return(ids, id_name)
+
+###############################################################################
+
+
+def main(argv):
+    logger = logging.getLogger(__name__)
+    args = Parser().parse(argv)
+    logger.debug(f"args: {args!r}")
+    api = jamf.API()
+    pprint(args)
+    if args.arg1 == 'package':
+        if 'info' in args.arg2:
+            print("package info")
+        if 'list' in args.arg2:
+            print("package list")
+        if 'remove' in args.arg2:
+            print("package remove")
+        if 'update' in args.arg2:
+            print("package update")
+        if 'upload' in args.arg2:
+            print("package upload")
+
+    elif args.arg1 == 'patch':
+        if 'list' in args.arg2:
+            list_softwaretitles(api, args.name)
+        elif 'update' in args.arg2:
+            print("patch update")
+
+    elif args.arg1 == 'policy':
+        if 'list' in args.arg2:
+            print_policies_ids(api)
+
+
+if __name__ == '__main__':
+    # check_version()
+    fmt = '%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s'
+    logging.basicConfig(level=logging.INFO, format=fmt)
+    main(sys.argv[1:])

--- a/jctl
+++ b/jctl
@@ -16,8 +16,8 @@ __author__ = 'Sam Forester'
 __email__ = 'sam.forester@utah.edu'
 __copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
 __license__ = 'MIT'
-__version__ = "1.0.5"
-min_jamf_version = "0.4.8"
+__version__ = "1.0.6"
+min_jamf_version = "0.4.9"
 
 
 from pprint import pprint
@@ -56,7 +56,10 @@ class Parser:
              description='Valid Jamf Records are: '+', '.join(valid_jamf_records))
         info.add_argument('record', metavar='RECORD',
             choices=valid_jamf_records, help='print jamf record info')
-        info.add_argument('name', metavar='NAME', help='print jamf record info')
+        info.add_argument('name', metavar='NAME', nargs='*',
+            help='print jamf record info')
+        info.add_argument('-p', '--path', action='append',
+            help='Print out path (e.g. \'-p general -p serial_number\'')
 
         # Package args
         info.add_argument('-f', '--file', action='store_true',
@@ -355,47 +358,58 @@ def main(argv):
     else:
         api = jamf.API()
 
+    if args.record:
+        jamf_record = jamf.records.class_name(args.record)
+
     ###########################################################################
     # Info
     if args.arg1 == 'info':
-        if args.file:
-            if args.record == "Packages":
-                # `patch.py info FILE`
-                pprint(Package(args.name).apps)
-            else:
-                print("-f only works for Packages")
-                exit(1)
+        for name in args.name:
+            if args.file:
+                if args.record == "Packages":
+                    # `patch.py info FILE`
+                    pprint(Package(name).apps)
+                else:
+                    print("-f only works for Packages")
+                    exit(1)
 
-        elif args.patches:
-            if args.record == "PatchSoftwareTitles":
-                # `patch.py list --patches NAME`
-                list_softwaretitle_policy_versions(api, args.name)
-            else:
-                print("-P only works for PatchSoftwareTitles")
-                exit(1)
+            elif args.patches:
+                if args.record == "PatchSoftwareTitles":
+                    # `patch.py list --patches NAME`
+                    list_softwaretitle_policy_versions(api, name)
+                else:
+                    print("-P only works for PatchSoftwareTitles")
+                    exit(1)
 
-        elif args.versions:
-            if args.record == "PatchSoftwareTitles":
-                # `patch.py list --versions NAME`
-                list_softwaretitle_versions(api, args.name)
-            else:
-                print("-v only works for PatchSoftwareTitles")
-                exit(1)
-
-        else:
-            if args.record in ["PatchSoftwareTitles"]:
-                # Workaround (PatchSoftwareTitles doesn't have name search)
-                id = jamf.records.class_name(args.record)().id(args.name)
-                jamf.records.class_name(args.record)(id).print()
+            elif args.versions:
+                if args.record == "PatchSoftwareTitles":
+                    # `patch.py list --versions NAME`
+                    list_softwaretitle_versions(api, name)
+                else:
+                    print("-v only works for PatchSoftwareTitles")
+                    exit(1)
 
             else:
-                # EVERYTHING ELSE
-                jamf.records.class_name(args.record)(args.name).print()
+                if args.record in ["PatchSoftwareTitles"]:
+                    # Workaround (PatchSoftwareTitles doesn't have name search)
+                    # This might need to be made generic in records.py
+                    id = jamf_record().id(name)
+                    if args.path:
+                        print(jamf_record(id).path(args.path))
+                    else:
+                        jamf_record(id).print()
+
+                else:
+                    # EVERYTHING ELSE
+                    if args.path:
+                        print(jamf_record(name).path(args.path))
+                    else:
+                        jamf_record(name).print()
 
     ###########################################################################
     # List
     elif args.arg1 == 'list':
-        jamf.records.class_name(args.record)().list(args.name)
+        jamf_record().list(args.name)
 
     ###########################################################################
     # New

--- a/jctl
+++ b/jctl
@@ -12,9 +12,9 @@ $> pctl policy list
 """
 
 
-__author__ = 'James Reynolds'
-__email__ = 'reynolds@biology.utah.edu'
-__copyright__ = 'Copyright (c) 2020, The University of Utah'
+__author__ = 'Sam Forester'
+__email__ = 'sam.forester@utah.edu'
+__copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
 __license__ = 'MIT'
 __version__ = "1.0.4"
 min_jamf_version = "0.4.7"
@@ -37,29 +37,78 @@ class Parser:
         self.parser = argparse.ArgumentParser()
         # https://docs.python.org/3/library/argparse.html
 
+        self.parser.add_argument('-c', '--config',
+                            help='path to config file')
+
         desc = 'see `%(prog)s COMMAND --help` for more information'
         self.subparsers = self.parser.add_subparsers(title='COMMANDS',
                             dest='arg1',
-                            metavar='{package|patch|policy}',
+                            metavar='{category|computer|computer_group|package|patch|policy}',
                             required=True,
                             description=desc)
 
-        # Package
-        package = self.subparsers.add_parser('package',
-                            help='info, list, remove, update, upload',
+        # Categories
+        category = self.subparsers.add_parser('category',
+                            help='list, update',
                             description="")
-        package2 = package.add_subparsers(title='SUBCOMMANDS',
-                            metavar='{info|list|remove|update|upload}',
+        category2 = category.add_subparsers(title='SUBCOMMANDS',
+                            metavar='{list}',
                             dest='arg2',
                             required=True)
-        package2.add_parser('info',
-                            help='Package info')
-        package2.add_parser('list',
-                            help='List all packages')
+        category2.add_parser('list',
+                            help='List all categories')
+
+        # Computers
+        computer = self.subparsers.add_parser('computer', help='list',
+                            description="")
+        computer2 = computer.add_subparsers(title='SUBCOMMANDS',
+                            metavar='{list}',
+                            dest='arg2',
+                            required=True)
+        computer2.add_parser('list',
+                            help='List all computers')
+
+        # Computer Group
+        computer_group = self.subparsers.add_parser('computer_group',
+                            help='list',
+                            description="")
+        computer_group2 = computer_group.add_subparsers(title='SUBCOMMANDS',
+                            metavar='{list}',
+                            dest='arg2',
+                            required=True)
+        computer_group2.add_parser('list',
+                            help='List all computer groups')
+
+        # Config Profiles
+        config_profile = self.subparsers.add_parser('config_profile', help='list',
+                            description="")
+        config_profile2 = config_profile.add_subparsers(title='SUBCOMMANDS',
+                            metavar='{list}',
+                            dest='arg2',
+                            required=True)
+        config_profile2.add_parser('list',
+                            help='List all Config Profiles')
+
+        # Package
+        package = self.subparsers.add_parser('package',
+                            help='info, list, remove, upload',
+                            description="")
+        package2 = package.add_subparsers(title='SUBCOMMANDS',
+                            metavar='{info|list|remove|upload}',
+                            dest='arg2',
+                            required=True)
+        package_info = package2.add_parser('info',
+                            help='get info about packages')
+        package_info.add_argument('path', metavar='PACKAGE',
+                            help='path to package')
+
+        package_list = package2.add_parser('list',
+                            help='list packages starting with NAME (or all if no NAME) (was `patch.py list --pkgs`)')
+        package_list.add_argument('name', metavar='NAME', action='store', nargs='?',
+                            help='list patch that starts with name')
+
         package2.add_parser('remove',
                             help='Remove a package')
-        package2.add_parser('update',
-                            help='Update a package description')
         package2.add_parser('upload',
                             help='Upload package')
 
@@ -72,15 +121,13 @@ class Parser:
                             dest='arg2',
                             required=True)
         patch_list = patch2.add_parser('list',
-                            help='without arguments, list all software titles (was `./patch.py list`)')
+                            help='without arguments, list all software titles (was `./patch.py list [NAME]`)')
         patch_list.add_argument('name', metavar='NAME', action='store', nargs='?',
                             help='list patch that starts with name')
-        patch_list.add_argument('-p', '--pkgs', action='store_true',
-                            help='list jss packages starting with NAME (or all if no NAME)')
         patch_list.add_argument('-P', '--patches', action='store_true',
                             help='list patch policies current versions for SoftwareTitle NAME')
         patch_list.add_argument('-v', '--versions', action='store_true',
-                            help='list SoftwareTitle versions and packages for NAME')
+                            help='list SoftwareTitle versions and packages for NAME (was `patch.py list --versions NAME`)')
 
         patch2.add_parser('update',
                             help='Update patch')
@@ -127,6 +174,24 @@ def check_version():
 # Package
 ###############################################################################
 
+def list_packages(api, name=None):
+    p = api.get('packages')
+    pkgs = p['packages']['package']
+    if name:
+        # only names that start with name (case-sensitive)
+        result = [x['name'] for x in pkgs if x['name'].lower().startswith(name.lower())]
+    else:
+        # all names
+        result = [x['name'] for x in pkgs]
+    # print sorted list of resulting Patch SoftwareTitle names
+    for n in sorted(result):
+        print(n)
+
+# def package_notes(path):
+#     path = pathlib.Path(path)
+#     *name, ver, date, author = path.stem.split('_')
+#     return f"{date}, {author.upper()}"
+
 ###############################################################################
 # Patch
 ###############################################################################
@@ -143,6 +208,164 @@ def list_softwaretitles(api, name=None):
     # print sorted list of resulting Patch SoftwareTitle names
     for n in sorted(result):
         print(n)
+
+def list_softwaretitle_versions(api, name):
+    title = find_softwaretitle(api, name)['patch_software_title']
+    versions = []
+    # get each version and assoiciated package (if one)
+    for version in title['versions']['version']:
+        v = version['software_version']
+        # {name of pkg} or '-'
+        p = version['package']['name'] if version['package'] else '-'
+        versions.append((v, p))
+    # print formatted result
+    print_version_key_list(versions)
+
+def find_softwaretitle(api, name, details=True):
+    """
+    :param api:         jamf.api.API object
+    :param name:        name of softwaretitle
+    :param details:     if False, return simple (id + name) (default: True)
+
+    :returns:           patch softwaretitle information
+    """
+    logger = logging.getLogger(__name__)
+    logger.debug(f"looking for existing software title: {name}")
+    # Iterate all Patch Management Titles for specified matching name
+    data = api.get('patchsoftwaretitles')['patch_software_titles']
+    for title in data['patch_software_title']:
+        if title['name'] == name:
+            logger.debug(f"found title: {name!r}")
+            if details:
+                logger.debug("returning detailed title info")
+                jssid = title['id']
+                return api.get(f"patchsoftwaretitles/id/{jssid}")
+            else:
+                logger.debug("returning simple title info")
+                return title
+    raise ValueError(f"missing software title: {name!r}")
+
+def print_version_key_list(versions):
+    """
+    Prints formatted (justified) list of key/value tuple pairs
+
+    e.g.  [('1.0', 'justified text'),
+           ('1.0.0', '-'),
+           ('2.0', ''),
+           ('2.0.0.2.a', 'longest version key')]
+    would print:
+    '''
+      1.0:        justified text
+      1.0.0:      -
+      2.0:
+      2.0.0.2.a:  longest version key
+    '''
+
+    :param versions <list>:  list of tuple key/value pairs
+                              e.g. [('1.O', 'info'), ('1.0.0', 'more'), ...]
+    """
+    # get length of the longest key
+    longest = sorted([len(k) for k, v in versions])[-1]
+    for ver, value in versions:
+        # dynamic right-justification of value based on longest version key
+        justification = (longest - len(ver)) + len(value)
+        print(f"  {ver}:  {value:>{justification}}")
+
+# def list_softwaretitle_policy_versions(api, name):
+#     jssid = find_softwaretitle(api, name, details=False)['id']
+#     versions = []
+#     for patch in softwaretitle_policies(api, jssid):
+#         p = api.get(f"patchpolicies/id/{patch['id']}")
+#         version = p['patch_policy']['general']['target_version']
+#         versions.append((version, patch['name']))
+#     # print formatted result
+#     print_version_key_list(versions)
+#
+# def softwaretitle_policies(api, jssid):
+#     """
+#     :returns: list of software title patch policies
+#     """
+#     endpoint = f"patchpolicies/softwaretitleconfig/id/{jssid}"
+#     return api.get(endpoint)['patch_policies']['patch_policy']
+#
+# def update_softwaretitle_versions(api, name, versions, pkgs=None):
+#     """
+#     Update all
+#     :param api:      JSS API object
+#     :param name:     name of external patch definition
+#     :param versions: {'Tech': version, 'Guinea Pig': version, 'Stable': version}
+#     :returns:
+#     """
+#     logger = logging.getLogger(__name__)
+#     jssid = find_softwaretitle(api, name, details=False)['id']
+#
+#     if pkgs:
+#         update_softwaretitle_packages(api, jssid, pkgs)
+#
+#     for p in softwaretitle_policies(api, jssid):
+#         # 'Tech - Test Boxes - Keynote' -> 'Tech'
+#         # 'Guinea Pig - Lab - Xcode' -> 'Guinea Pig'
+#         branch = p['name'].split(' - ')[0]
+#         try:
+#             update_patch_policy_version(api, p['id'], versions[branch])
+#         except KeyError:
+#             logger.debug(f"skipping: {p['name']!r}")
+#
+# def update_patch_policy_version(api, jssid, version):
+#     """
+#     Update Patch Policy version
+#     """
+#     logger = logging.getLogger(__name__)
+#     current = api.get(f"patchpolicies/id/{jssid}")
+#     current_version = current['patch_policy']['general']['target_version']
+#     name = current['patch_policy']['general']['name']
+#
+#     if current_version != version:
+#         logger.info(f"updating: {name!r}: {version}")
+#         data = {'patch_policy': {'general': {'target_version': version}}}
+#         api.put(f"patchpolicies/id/{jssid}", data)
+#     else:
+#         logger.debug(f"already updated: {name}: {version}")
+#
+# def update_softwaretitle_packages(api, jssid, pkgs):
+#     """
+#     Update packages of software title
+#     :param jssid:        Patch Software Title ID
+#     :param pkgs:         dict of {version: package, ...}
+#     :returns: None
+#     """
+#     logger = logging.getLogger(__name__)
+#
+#     data = api.get(f"patchsoftwaretitles/id/{jssid}")
+#     title = data['patch_software_title']
+#
+#     title_name = title['name']
+#     logger.info(f"updating patch software title: {title_name} ({jssid})")
+#
+#     # single version (dict), multiple versions (list)
+#     version = title['versions']['version']
+#     _modified = False
+#     try:
+#         # access key of single version and count on TypeError being raised
+#         v = version['software_version']
+#         if v in pkgs.keys():
+#             version['package'] = {'name': pkgs[v]}
+#             _modified = True
+#
+#     except TypeError:
+#         # looks like it was actually a list
+#         for _version in version:
+#             v = _version['software_version']
+#             if v in pkgs.keys():
+#                 _version['package'] = {'name': pkgs[v]}
+#                 _modified = True
+#
+#     if _modified:
+#         result = api.put(f"patchsoftwaretitles/id/{jssid}", data)
+#         logger.info(f"succesfully updated: {title_name}")
+#         return result
+#     else:
+#         logger.info(f"software title was not modified")
 
 ###############################################################################
 # Policy
@@ -167,28 +390,104 @@ def main(argv):
     logger = logging.getLogger(__name__)
     args = Parser().parse(argv)
     logger.debug(f"args: {args!r}")
-    api = jamf.API()
     pprint(args)
-    if args.arg1 == 'package':
-        if 'info' in args.arg2:
-            print("package info")
+
+    if args.config:
+        api = jamf.API(config_path=args.config)
+    else:
+        api = jamf.API()
+
+    if args.arg1 == 'category':
         if 'list' in args.arg2:
-            print("package list")
+            print("category list")
+    elif args.arg1 == 'computer':
+        if 'list' in args.arg2:
+            print("computer list")
+    elif args.arg1 == 'computer_group':
+        if 'list' in args.arg2:
+            print("computer_group list")
+    elif args.arg1 == 'config':
+        if 'list' in args.arg2:
+            print("config list")
+    elif args.arg1 == 'config_profile':
+        if 'list' in args.arg2:
+            print("config_profile list")
+
+    elif args.arg1 == 'package':
+        if 'info' in args.arg2:
+            pprint(Package(args.path).apps)
+
+        if 'list' in args.arg2:
+            # `patch.py list --pkgs`
+            list_packages(api, args.name)
+
         if 'remove' in args.arg2:
             print("package remove")
-        if 'update' in args.arg2:
-            print("package update")
+
+#             path = pathlib.Path(args.name)
+#             if path.name != str(path):
+#                 raise SystemExit("must specify package name not path")
+#             admin = jamf.JamfAdmin()
+#             try:
+#                 pkg = admin.find(path.name)
+#             except jamf.admin.MissingPackageError:
+#                 logger.error(f"package already removed: {path.name}")
+#             else:
+#                 admin.delete(pkg)
+
         if 'upload' in args.arg2:
             print("package upload")
 
+#             pkg = Package(args.path)
+#             # try:
+#             #     info = pkg.info
+#             # except Exception:
+#             #     raise SystemExit(f"invalid package: {args.path!r}")
+#             admin = jamf.admin.JamfAdmin()
+#             #admin = jamf.Admin()
+#             try:
+#                 uploaded = admin.add(pkg)
+#             except jamf.admin.DuplicatePackageError as e:
+#                 if not args.force:
+#                     raise e
+#                 uploaded = admin.find(pkg.name)
+#             admin.update(uploaded, notes=package_notes(uploaded.path))
+
     elif args.arg1 == 'patch':
         if 'list' in args.arg2:
-            list_softwaretitles(api, args.name)
+            if args.patches:
+                # `patch.py list --patches NAME`
+                if not args.name:
+                    raise SystemExit("ERROR: must specify SoftwareTitle name")
+                list_softwaretitle_policy_versions(api, args.name)
+            elif args.versions:
+                # `patch.py list --versions NAME`
+                if not args.name:
+                    raise SystemExit("ERROR: must specify SoftwareTitle name")
+                list_softwaretitle_versions(api, args.name)
+            else:
+                # `patch.py list [NAME]`
+                list_softwaretitles(api, args.name)
+
         elif 'update' in args.arg2:
             print("patch update")
 
+#             # update patch software titles and/or patch policies
+#             v = {'Tech': args.tech,
+#                  'Guinea Pig': args.guinea_pig,
+#                  'Stable': args.stable}
+#             versions = {k:v for k, v in v.items() if v}
+#             pkgs = {x[0]: x[1] for x in args.pkg}
+#
+#             logger.debug(f"NAME: {args.name}")
+#             logger.debug(f"VERSIONS: {versions!r}")
+#             logger.debug(f"PKGS: {pkgs!r}")
+#
+#             update_softwaretitle_versions(api, args.name, versions, pkgs)
+
     elif args.arg1 == 'policy':
         if 'list' in args.arg2:
+            # `patch.py list --ids`
             print_policies_ids(api)
 
 


### PR DESCRIPTION
I took O'Ryan's version and hacked it up. This version is a working version.

Commands that work:

```
jctl package info PACKAGE        # was patch.py info PACKAGE
jctl package list                # was patch.py list --pkgs
jctl patch list [NAME]           # was patch.py list [NAME]
jctl patch list -v NAME          # was patch.py list --versions NAME
jctl patch list -p NAME          # was patch.py list --patches NAME
jctl policy list                 # was patch.py list --ids
```

The code from patch.py that isn't reconnected is in jctl but it's commented out. This is Sam's old code, I haven't modified it at all. It's these commands:

```
jctl package remove *            # was patch.py remove *
jctl package upload *            # was patch.py upload *
jctl patch update *              # was patch.py update *
```

I removed the add_argument_group because it did some strange stuff (at the very top of that snapshot you sent it says "list update list update info list upload remove list"). I still don't completely understand the arg parser but it makes a little bit more sense now. I also had to add more subparsers for each command.

I've added placeholders for:

```
jctl category list
jctl computer list
jctl computer_group list
jctl config_profile list
```