### PR TITLE
Add pre-commit configuration and corresponding GH Actions job

### DIFF
--- a/.github/workflows/pre-commit.sh
+++ b/.github/workflows/pre-commit.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+pip install pre-commit
+
+# Run pre-commit: if no errors, exit zero
+pre-commit run --all-files && exit 0
+
+# If we had errors but no changes to code, exit non-zero
+git diff --exit-code && exit 1
+
+# Commit and push changes made by pre-commit hooks
+git config user.name github-actions
+git config user.email github-actions@github.com
+git add -A
+git commit -anm "pre-commit auto fixes" || true
+git push || true
+
+# Run pre-commit again, passing through exit code
+pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,19 @@
+name: pre-commit
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Linting checks
+        run: .github/workflows/pre-commit.sh

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-added-large-files
+        args: [--maxkb=100]
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+  - repo: https://github.com/python/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort

--- a/jctl/jctl
+++ b/jctl/jctl
@@ -110,7 +110,6 @@ class Parser:
             "confirmation. DANGER! This can delete everything FAST!",
         )
 
-
     def str_to_json(self, value_):
         try:
             json_dump_ = json.dumps(ast.literal_eval(value_))

--- a/jctl/jctl
+++ b/jctl/jctl
@@ -14,15 +14,16 @@ __version__ = "1.1.15"
 min_jamf_version = "0.6.9"
 
 
-from pprint import pprint
 import argparse
 import ast
-import jamf
 import json
 import logging
 import re
 import sys
 import time
+from pprint import pprint
+
+import jamf
 
 
 class Parser:

--- a/jctl/patch.py
+++ b/jctl/patch.py
@@ -41,18 +41,14 @@ __version__ = "1.0.4"
 min_jamf_version = "0.6.9"
 
 
-import sys
-import logging
-import pprint
-import pathlib
 import argparse
+import logging
+import pathlib
+import pprint
+import sys
 
 import jamf
-
-# import jamf.admin
 from jamf.package import Package
-
-# import jamf.config
 
 
 class Parser:

--- a/jctl/pkgctl
+++ b/jctl/pkgctl
@@ -13,15 +13,16 @@ __version__ = "0.8.1"
 min_jamf_version = "0.7.3"
 
 
-from pprint import pprint
 import argparse
 import ast
-import jamf
 import json
 import logging
 import re
 import sys
 import time
+from pprint import pprint
+
+import jamf
 
 
 class Parser:

--- a/jctl/pkgctl
+++ b/jctl/pkgctl
@@ -14,12 +14,8 @@ min_jamf_version = "0.7.3"
 
 
 import argparse
-import ast
-import json
 import logging
-import re
 import sys
-import time
 from pprint import pprint
 
 import jamf

--- a/jctl/pkgctl
+++ b/jctl/pkgctl
@@ -142,8 +142,10 @@ def process_package_promotion(item, packages):
                     rec.save()
                 except jamf.api.APIError as e:
                     print(f"Error - {e}")
-                    print("This utility is no longer in sync with the Jamf,"
-                          " server. Continue only if you know what you're doing.")
+                    print(
+                        "This utility is no longer in sync with the Jamf,"
+                        " server. Continue only if you know what you're doing."
+                    )
                 rec.refresh()
                 new_package.refresh_related()
                 print(f"Saved patch policiy named {item[1]}")
@@ -162,8 +164,10 @@ def process_package_promotion(item, packages):
                             rec.save()
                         except jamf.api.APIError as e:
                             print(f"Error - {e}")
-                            print("This utility is no longer in sync with the Jamf,"
-                                  " server. Continue only if you know what you're doing.")
+                            print(
+                                "This utility is no longer in sync with the Jamf,"
+                                " server. Continue only if you know what you're doing."
+                            )
                         rec.refresh()
                         package.refresh_related()
                         print(f"Saved policy named {item[1]}")
@@ -181,8 +185,10 @@ def process_package_promotion(item, packages):
                             rec.save()
                         except jamf.api.APIError as e:
                             print(f"Error - {e}")
-                            print("This utility is no longer in sync with the Jamf,"
-                                  " server. Continue only if you know what you're doing.")
+                            print(
+                                "This utility is no longer in sync with the Jamf,"
+                                " server. Continue only if you know what you're doing."
+                            )
                         rec.refresh()
                         package.refresh_related()
                         print(f"Saved computer group named {item[1]}")
@@ -251,9 +257,7 @@ def print_groups(packages, related=False, group_index=False):
                 if related:
                     text += " - "
                     if "PatchSoftwareTitles" in child.related:
-                        text += (
-                            f"patch {len(child.related['PatchSoftwareTitles'])}; "
-                        )
+                        text += f"patch {len(child.related['PatchSoftwareTitles'])}; "
                     if "Policies" in child.related:
                         text += f"Policies {len(child.related['Policies'])}; "
                     if "ComputerGroups" in child.related:
@@ -261,9 +265,7 @@ def print_groups(packages, related=False, group_index=False):
                             f"ComputerGroups {len(child.related['ComputerGroups'])}; "
                         )
                     if "PatchPolicies" in child.related:
-                        text += (
-                            f"PatchPolicies {len(child.related['PatchPolicies'])}; "
-                        )
+                        text += f"PatchPolicies {len(child.related['PatchPolicies'])}; "
                 text += "\n"
             print(f"{text}")
     return group_choices

--- a/jctl/update_asset_tags.py
+++ b/jctl/update_asset_tags.py
@@ -10,6 +10,7 @@ __license__ = "MIT"
 
 import csv
 import logging
+
 import jamf
 
 # create inventory lookup for each asset tag by serial number

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-import setuptools
 import re
+
+import setuptools
 
 
 def get_property(prop, file):


### PR DESCRIPTION
Similar to https://github.com/univ-of-utah-marriott-library-apple/python-jamf/pull/73, this pull request creates a [pre-commit](https://pre-commit.com/) configuration and GitHub Actions job that runs it upon submitting PRs or pushing to `main`. The configuration allows Black and iSort format to be applied automatically upon push. There are also other minor pre-commit checks included, all of which the codebase already complies with.